### PR TITLE
Add Gemini workflow for Slack summaries

### DIFF
--- a/.github/workflows/gemini-slack-summary.yml
+++ b/.github/workflows/gemini-slack-summary.yml
@@ -1,0 +1,47 @@
+name: Gemini Slack Summary
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  summarize-slack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Run Gemini Slack Summary
+        uses: google-gemini/gemini-cli-action@main
+        env:
+          SLACK_MCP_XOXC_TOKEN: ${{ secrets.SLACK_MCP_XOXC_TOKEN }}
+          SLACK_MCP_XOXD_TOKEN: ${{ secrets.SLACK_MCP_XOXD_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+        with:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          settings_json: |
+            {
+              "mcpServers": {
+                "slack": {
+                  "command": "npx",
+                  "args": ["-y", "slack-mcp-server@latest", "--transport", "stdio"],
+                  "env": {
+                    "SLACK_MCP_XOXC_TOKEN": "$SLACK_MCP_XOXC_TOKEN",
+                    "SLACK_MCP_XOXD_TOKEN": "$SLACK_MCP_XOXD_TOKEN"
+                  }
+                }
+              },
+              "coreTools": [
+                "slack__conversations_history",
+                "run_shell_command(curl)"
+              ]
+            }
+          prompt: |
+            あなたはSlackのサマリーを作成するアシスタントです。
+            1. `slack__conversations_history` を利用して `$SLACK_CHANNEL_ID` の直近1日のメッセージを取得し、その際に使用したパラメータ (channel, oldest, latest) を標準出力に表示してください。
+            2. メッセージから主要なトピックや頻繁に共有されたリンクを特定してください。
+            3. 結果を短い段落と人気記事の箇条書きで要約してください。
+            4. `run_shell_command` を使用して Slack Web API を呼び出し、要約結果を Slack に投稿してください:
+               `curl -X POST -H 'Authorization: Bearer $SLACK_BOT_TOKEN' -H 'Content-Type: application/json' \
+               --data '{"channel":"$SLACK_CHANNEL_ID","text":"<summary>"}' https://slack.com/api/chat.postMessage`


### PR DESCRIPTION
## Summary
- add a new workflow to summarize one day of Slack messages using gemini-cli-action and slack-mcp-server
- translate the prompt to Japanese and instruct the tool to print slack history parameters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686326c48cc0832baff7762a0b7b76cb