### PR TITLE
Improve guidelines update workflow

### DIFF
--- a/.github/workflows/update-gist.yml
+++ b/.github/workflows/update-gist.yml
@@ -1,0 +1,32 @@
+name: Update App Store Review Guidelines Gist
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install pandoc and GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc gh
+
+      - name: Fetch review guidelines
+        run: curl -L https://developer.apple.com/app-store/review/guidelines/ -o guidelines.html
+
+      - name: Convert HTML to Markdown
+        run: pandoc guidelines.html -f html -t gfm -o guidelines.md
+
+      - name: Authenticate gh
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: echo "$GH_TOKEN" | gh auth login --with-token
+
+      - name: Update gist
+        env:
+          GIST_ID: ${{ secrets.GIST_ID }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: gh gist edit "$GIST_ID" guidelines.md


### PR DESCRIPTION
## Summary
- schedule workflow daily
- use `GH_TOKEN` for authentication

## Testing
- `gh --version`
- `pandoc --version`
- `curl -I https://developer.apple.com/app-store/review/guidelines/`


------
https://chatgpt.com/codex/tasks/task_e_6868901faba0832b95bfdd7f7e847290