### PR TITLE
Update Bluesky summary workflow

### DIFF
--- a/.github/workflows/gemini-bluesky-summary.yml
+++ b/.github/workflows/gemini-bluesky-summary.yml
@@ -1,0 +1,46 @@
+name: Gemini Bluesky Summary
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 23 * * *'
+
+jobs:
+  summarize-bluesky:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Run Gemini Bluesky Summary
+        uses: google-gemini/gemini-cli-action@main
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_TEAM_ID: ${{ secrets.SLACK_TEAM_ID }}
+        with:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          settings_json: |
+            {
+              "mcpServers": {
+                "slack": {
+                  "command": "npx",
+                  "args": ["-y", "@modelcontextprotocol/server-slack"],
+                  "env": {
+                    "SLACK_BOT_TOKEN": "$SLACK_BOT_TOKEN",
+                    "SLACK_TEAM_ID": "$SLACK_TEAM_ID"
+                  }
+                }
+              },
+              "coreTools": [
+                "run_shell_command(curl)"
+              ]
+            }
+          prompt: >-
+            あなたは Bluesky 投稿のまとめアシスタントです。
+            `curl -sL
+            https://bsky.app/profile/did:plc:a3vurmxtfdiehvyefas744uc/feed/aaalzlquduqha`
+            を実行し、HTML を取得してください。
+            1. 日本時間の昨日投稿されたメッセージを抽出してください。
+            2. いいね数が多い順に上位5件を選び、各メッセージ本文といいね数をそのまま列挙してください。要約は不要です。
+            3. 結果を Slack の `#general` チャンネルに投稿します。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## GitHub ワークフロー
 
-リポジトリには二つのワークフローがあり、どちらも **google-gemini/gemini-cli-action** を利用しています。
+リポジトリには三つのワークフローがあり、いずれも **google-gemini/gemini-cli-action** を利用しています。
 
 ### Gemini Slack Summary
 - [`gemini-slack-summary.yml`](.github/workflows/gemini-slack-summary.yml) に定義
@@ -12,6 +12,12 @@
 - `SLACK_BOT_TOKEN`、`SLACK_TEAM_ID`、`GEMINI_API_KEY` を設定して `google-gemini/gemini-cli-action@main` を呼び出す
 - `settings_json` で MCP の Slack サーバーを起動し `mcp__slack__slack_get_channel_history` を利用
 - `#rss-tech_blog` `#rss-hotentry` `#rss-ai` `#rss-ios` のメッセージを要約し `#general` に投稿
+
+### Gemini Bluesky Summary
+- [`gemini-bluesky-summary.yml`](.github/workflows/gemini-bluesky-summary.yml) に定義
+- 毎日と `workflow_dispatch` で実行
+- Slack サーバーを起動した上で `curl` を使い、Bluesky ページ `https://bsky.app/profile/did:plc:a3vurmxtfdiehvyefas744uc/feed/aaalzlquduqha` を取得
+- ページから昨日投稿された内容をいいね数の多い順に抽出し、メッセージ本文をそのまま `#general` に投稿
 
 ### Update App Store Review Guidelines Gist
 - [`update-gist.yml`](.github/workflows/update-gist.yml) に定義


### PR DESCRIPTION
## Summary
- refine gemini-bluesky-summary workflow to sort posts by likes and post them directly to Slack
- document the new selection method in AGENTS

## Testing
- `yamllint .github/workflows/gemini-bluesky-summary.yml` *(shows only warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686906fe2b44832b80448f76ac905238