### PR TITLE
fix: Contribution数抽出の正規表現パターンを修正

### DIFF
--- a/.github/workflows/qiita-contribution.yml
+++ b/.github/workflows/qiita-contribution.yml
@@ -32,7 +32,7 @@ jobs:
           
           # Qiita ページから HTML を取得し、Contribution 数を抽出
           HTML=$(curl -s https://qiita.com/zeero)
-          CURRENT_COUNT=$(echo "$HTML" | grep -o 'Contribution</span><span[^>]*>[0-9]*' | grep -o '[0-9]*$' | head -1)
+          CURRENT_COUNT=$(echo "$HTML" | grep 'meta.*content.*Contribution:' | grep -o 'Contribution: [0-9]*' | grep -o '[0-9]*')
           
           # Contribution 数が取得できない場合はエラー
           if [ -z "$CURRENT_COUNT" ]; then


### PR DESCRIPTION
## Summary
- meta contentから安定したContribution数抽出に変更
- 動的CSS classへの依存を排除して安定性を向上
- "Could not extract contribution count" エラーを解決

## 問題
現在のワークフローでは動的に生成されるCSS classを使用してContribution数を抽出していたため、HTML構造の変更により抽出が失敗していました。

## 解決策
meta description内の `Contribution: [数字]` パターンを使用することで、より安定した抽出を実現しました。

## Test plan
- [ ] ワークフローが手動実行で正常に動作することを確認
- [ ] Contribution数が正しく抽出されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)