### PR TITLE
Add periodic execution note to Bluesky workflow

### DIFF
--- a/.github/workflows/gemini-bluesky-summary.yml
+++ b/.github/workflows/gemini-bluesky-summary.yml
@@ -64,6 +64,7 @@ jobs:
             }
           prompt: |
             あなたは Bluesky 投稿のまとめアシスタントです。
+            この処理は定期実行しているためユーザへの確認は不要です。
             `mcp__bluesky__get_feed_posts` ツールを使い、
             フィード URI `at://did:plc:a3vurmxtfdiehvyefas744uc/app.bsky.feed.generator/aaalzlquduqha` から投稿を取得してください。
             1. 直近24時間に投稿されたメッセージを抽出してください。


### PR DESCRIPTION
## Summary
- remove redundant GitHub Action reminder from Slack summary
- add the periodic execution note to Bluesky summary workflow

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' .github/workflows/gemini-slack-summary.yml .github/workflows/gemini-bluesky-summary.yml`

------
https://chatgpt.com/codex/tasks/task_e_687854f4274c832b82186fd087db3c90