### PR TITLE
Remove schedule trigger from Swift Evolution Monitor workflow

### DIFF
--- a/.github/workflows/swift-evolution-monitor.yml
+++ b/.github/workflows/swift-evolution-monitor.yml
@@ -8,8 +8,6 @@ on:
         required: false
         default: ''
         type: string
-  schedule:
-    - cron: '0 5 * * *'  # 毎日日本時間14時（UTC 5時）
 
 jobs:
   monitor-swift-evolution:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - Swift Evolution プロポーザルの Accept/Implement 変更を監視
    - 2段階処理: GitHub API でコミット情報取得 → Gemini で分析・Slack通知
    - 手動実行時は任意の日付（日本時間）から監視可能
-   - 自動実行: 毎日15時（日本時間）
    - 必要なシークレット: `SLACK_BOT_TOKEN`, `SLACK_TEAM_ID`, `GEMINI_API_KEY`
 
 5. **その他のワークフロー**


### PR DESCRIPTION
This change removes the daily scheduled execution of the Swift Evolution Monitor workflow as requested. The workflow can still be triggered manually through the GitHub Actions interface. Documentation in CLAUDE.md has been updated to reflect this change.

---
*PR created automatically by Jules for task [17709265096610473507](https://jules.google.com/task/17709265096610473507) started by @zeero*